### PR TITLE
Fix work showcase video rendering

### DIFF
--- a/src/components/HomepageShowcase.astro
+++ b/src/components/HomepageShowcase.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
+import WorkMedia from './WorkMedia.astro';
 
 interface Props {
 	project: CollectionEntry<'work'>;
@@ -7,8 +8,6 @@ interface Props {
 
 const { project } = Astro.props;
 const { data, id } = project;
-const mediaPath = data.img.replace(/^\//, '');
-const posterPath = data.poster?.replace(/^\//, '');
 const href = data.externalUrl ?? `/work/${id}`;
 const isExternal = Boolean(data.externalUrl);
 ---
@@ -36,25 +35,7 @@ const isExternal = Boolean(data.externalUrl);
 		}
 	</header>
 
-	<div class="showcase-media">
-		{
-			data.mediaType === 'video' ? (
-				<video
-					autoplay
-					muted
-					loop
-					playsinline
-					preload="metadata"
-					poster={posterPath}
-					aria-label={data.img_alt || undefined}
-				>
-					<source src={mediaPath} type="video/mp4" />
-				</video>
-			) : (
-				<img src={mediaPath} alt={data.img_alt || ''} loading="lazy" decoding="async" />
-			)
-		}
-	</div>
+	<WorkMedia src={data.img} alt={data.img_alt} mediaType={data.mediaType} poster={data.poster} />
 </article>
 
 <style>
@@ -130,21 +111,6 @@ const isExternal = Boolean(data.externalUrl);
 		text-underline-offset: 0.25em;
 	}
 
-	.showcase-media {
-		width: 100%;
-		aspect-ratio: 5 / 3;
-		overflow: hidden;
-		border-radius: 1.5rem;
-		box-shadow: var(--shadow-sm);
-	}
-
-	.showcase-media > :is(img, video) {
-		display: block;
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
-
 	@media (min-width: 50em) {
 		.showcase {
 			grid-template-columns: 6fr 4fr;
@@ -154,8 +120,5 @@ const isExternal = Boolean(data.externalUrl);
 			border-radius: 4.5rem;
 		}
 
-		.showcase-media {
-			aspect-ratio: 5 / 3;
-		}
 	}
 </style>

--- a/src/components/PortfolioPreview-full.astro
+++ b/src/components/PortfolioPreview-full.astro
@@ -1,12 +1,12 @@
 ---
 import type { CollectionEntry } from 'astro:content';
+import WorkMedia from './WorkMedia.astro';
 
 interface Props {
 	project: CollectionEntry<'work'>;
 }
 
 const { data } = Astro.props.project;
-const imagePath = data.img.replace(/^\//, '');
 ---
 
 <section class="project showcase-card">
@@ -15,7 +15,7 @@ const imagePath = data.img.replace(/^\//, '');
 		<h3>{data.title}</h3>
 		<p class="showcase-argument">{data.showcaseArgument}</p>
 	</div>
-	<img src={imagePath} alt={data.img_alt || ''} loading="lazy" decoding="async" />
+	<WorkMedia src={data.img} alt={data.img_alt} mediaType={data.mediaType} poster={data.poster} />
 </section>
 
 <style>
@@ -71,14 +71,6 @@ const imagePath = data.img.replace(/^\//, '');
 		color: var(--text-secondary);
 	}
 
-	.project > img {
-		width: 100%;
-		height: auto;
-		aspect-ratio: 5 / 3;
-		border-radius: 1.5rem;
-		object-fit: cover;
-	}
-
 	@media (min-width: 50em) {
 		section {
 			padding: 4.5rem;
@@ -92,9 +84,5 @@ const imagePath = data.img.replace(/^\//, '');
 			border-radius: 4.5rem;
 		}
 
-		.project > img {
-			aspect-ratio: 5 / 3;
-			/*border-radius: 4.5rem;*/
-		}
 	}
 </style>

--- a/src/components/WorkMedia.astro
+++ b/src/components/WorkMedia.astro
@@ -1,0 +1,47 @@
+---
+interface Props {
+	src: string;
+	alt?: string;
+	mediaType?: 'image' | 'video';
+	poster?: string;
+}
+
+const { src, alt, mediaType = 'image', poster } = Astro.props;
+---
+
+<div class="work-media">
+	{
+		mediaType === 'video' ? (
+			<video
+				autoplay
+				muted
+				loop
+				playsinline
+				preload="metadata"
+				poster={poster}
+				aria-label={alt || undefined}
+			>
+				<source src={src} type="video/mp4" />
+			</video>
+		) : (
+			<img src={src} alt={alt || ''} loading="lazy" decoding="async" />
+		)
+	}
+</div>
+
+<style>
+	.work-media {
+		width: 100%;
+		aspect-ratio: 5 / 3;
+		overflow: hidden;
+		border-radius: 1.5rem;
+		box-shadow: var(--shadow-sm);
+	}
+
+	.work-media > :is(img, video) {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+</style>


### PR DESCRIPTION
## What changed

- Use one shared media renderer for homepage and `/work` showcase cards.
- Render video work records as muted, looping inline video and retain image rendering for image records.
- Preserve root-relative media paths and consistent 5:3 cropped thumbnails.

## Why

`/work` had a separate image-only renderer, so the Financial Services video record could not play there.

## Validation

- `npm run build`
- Verified generated `/work` markup uses the video source at `/images/case/financial-services.mp4`.