### PR TITLE
Add homepage positioning layer

### DIFF
--- a/src/components/PositioningStatements.astro
+++ b/src/components/PositioningStatements.astro
@@ -1,0 +1,132 @@
+<section class="positioning" aria-labelledby="positioning-title">
+	<h2 id="positioning-title" class="section-label">What I bring</h2>
+
+	<ol class="statements">
+		<li class="statement">
+			<span class="statement-number" aria-hidden="true">01</span>
+			<div class="statement-copy">
+				<h3>I design systems that adapt without fragmenting.</h3>
+				<p>
+					I turn accessibility, platform, and organizational constraints into flexible product
+					foundations that support different experiences without becoming separate products.
+				</p>
+			</div>
+		</li>
+
+		<li class="statement">
+			<span class="statement-number" aria-hidden="true">02</span>
+			<div class="statement-copy">
+				<h3>I move from strategy to working software.</h3>
+				<p>
+					I use AI-assisted development to prototype, validate, and ship while keeping the product
+					value grounded in real user needs.
+				</p>
+			</div>
+		</li>
+
+		<li class="statement">
+			<span class="statement-number" aria-hidden="true">03</span>
+			<div class="statement-copy">
+				<h3>I improve how teams make the work.</h3>
+				<p>
+					I redesign design systems and production workflows so teams can ship faster and more
+					consistently without sacrificing craft.
+				</p>
+			</div>
+		</li>
+	</ol>
+</section>
+
+<style>
+	.positioning {
+		border-block: 1px solid var(--border-subtle);
+		padding-block: 1.5rem 0.5rem;
+	}
+
+	.section-label {
+		font-size: var(--role-eyebrow-size);
+		font-weight: var(--weight-bold);
+		line-height: 1.4;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--text-tertiary);
+	}
+
+	.statements {
+		list-style: none;
+		padding: 0;
+		margin-top: 1rem;
+	}
+
+	.statement {
+		display: grid;
+		grid-template-columns: 2rem minmax(0, 1fr);
+		gap: 0.75rem;
+		padding-block: 1.5rem;
+		border-top: 1px solid var(--border-subtle);
+	}
+
+	.statement-number {
+		padding-top: 0.2rem;
+		font-size: var(--role-meta-size);
+		font-variant-numeric: tabular-nums;
+		line-height: 1.5;
+		color: var(--text-tertiary);
+	}
+
+	.statement-copy {
+		display: grid;
+		align-content: start;
+		gap: 0.75rem;
+	}
+
+	h3 {
+		max-width: 18ch;
+		font-size: var(--role-heading-size);
+		font-weight: var(--weight-heading);
+		line-height: 1.2;
+		letter-spacing: -0.02em;
+		text-wrap: balance;
+	}
+
+	p {
+		max-width: 42ch;
+		font-size: var(--role-body-size);
+		line-height: 1.55;
+		color: var(--text-secondary);
+	}
+
+	@media (min-width: 50em) {
+		.positioning {
+			padding-block: 2rem 3rem;
+		}
+
+		.statements {
+			display: grid;
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			margin-top: 2.5rem;
+		}
+
+		.statement {
+			display: grid;
+			grid-template-columns: 1fr;
+			gap: 1rem;
+			padding: 0 2rem;
+			border-top: 0;
+			border-left: 1px solid var(--border-subtle);
+		}
+
+		.statement:first-child {
+			padding-left: 0;
+			border-left: 0;
+		}
+
+		.statement:last-child {
+			padding-right: 0;
+		}
+
+		.statement-number {
+			padding-top: 0;
+		}
+	}
+</style>

--- a/src/components/PositioningStatements.astro
+++ b/src/components/PositioningStatements.astro
@@ -5,10 +5,10 @@
 		<li class="statement">
 			<span class="statement-number" aria-hidden="true">01</span>
 			<div class="statement-copy">
-				<h3>I design systems that adapt without fragmenting.</h3>
+				<h3>I design systems that adapt without fragmenting</h3>
 				<p>
-					I turn accessibility, platform, and organizational constraints into flexible product
-					foundations that support different experiences without becoming separate products.
+					turning accessibility and platform constraints into shared foundations that support meaningful
+					variation.
 				</p>
 			</div>
 		</li>
@@ -16,10 +16,10 @@
 		<li class="statement">
 			<span class="statement-number" aria-hidden="true">02</span>
 			<div class="statement-copy">
-				<h3>I move from strategy to working software.</h3>
+				<h3>I move from strategy to working software</h3>
 				<p>
-					I use AI-assisted development to prototype, validate, and ship while keeping the product
-					value grounded in real user needs.
+					using AI-assisted development to prototype, validate, and ship products grounded in real user
+					needs.
 				</p>
 			</div>
 		</li>
@@ -27,11 +27,8 @@
 		<li class="statement">
 			<span class="statement-number" aria-hidden="true">03</span>
 			<div class="statement-copy">
-				<h3>I improve how teams make the work.</h3>
-				<p>
-					I redesign design systems and production workflows so teams can ship faster and more
-					consistently without sacrificing craft.
-				</p>
+				<h3>I improve how teams make the work</h3>
+				<p>redesigning systems and workflows so teams can ship faster without sacrificing craft.</p>
 			</div>
 		</li>
 	</ol>
@@ -81,7 +78,6 @@
 	}
 
 	h3 {
-		max-width: 18ch;
 		font-size: var(--role-heading-size);
 		font-weight: var(--weight-heading);
 		line-height: 1.2;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import ContactCTA from '../components/ContactCTA.astro';
 import Hero from '../components/Hero.astro';
 import HomepageShowcase from '../components/HomepageShowcase.astro';
 import Icon from '../components/Icon.astro';
-import Skills from '../components/Skills.astro';
+import PositioningStatements from '../components/PositioningStatements.astro';
 import { getCollection } from 'astro:content';
 import { sortWorkProjects } from '../utils/work-order';
 
@@ -46,7 +46,9 @@ const homepageProjects = (await getCollection('work'))
 
 		<div class="hero-work-gap" aria-hidden="true"></div>
 
-		<main class="wrapper stack gap-20">
+		<main class="wrapper stack gap-15 lg:gap-20">
+			<PositioningStatements />
+
 			<section class="work" aria-label="Selected work">
 				{homepageProjects.map((project) => <HomepageShowcase project={project} />)}
 			</section>
@@ -56,13 +58,6 @@ const homepageProjects = (await getCollection('work'))
 					View all work →
 				</CallToAction>
 			</div>
-
-			<section class="services with-background bg-variant">
-				<header class="stack gap-2 lg:gap-4">
-					<h3>Services</h3>
-					<Skills />
-				</header>
-			</section>
 		</main>
 
 		<ContactCTA />
@@ -109,34 +104,6 @@ const homepageProjects = (await getCollection('work'))
 		justify-content: center;
 	}
 
-	.services {
-		position: relative;
-	}
-
-	/* title role */
-	.services h3 {
-		font-size: var(--role-title-size);
-		font-weight: var(--weight-display);
-		letter-spacing: -0.03em;
-	}
-
-	.with-background::before {
-		--hero-bg: var(--bg-image-subtle-1);
-		content: '';
-		position: absolute;
-		pointer-events: none;
-		left: 50%;
-		width: 100vw;
-		aspect-ratio: calc(2.25 / var(--bg-scale));
-		top: 0;
-		transform: translateY(-75%) translateX(-50%);
-		background: url('../images/backgrounds/noise.png') top center/220px repeat,
-			var(--hero-bg) center center / var(--bg-gradient-size) no-repeat, var(--surface-page);
-		background-blend-mode: overlay, normal, normal, normal;
-		mix-blend-mode: var(--bg-blend-mode);
-		z-index: -1;
-	}
-
 	@media (min-width: 50em) {
 		.hero {
 			display: grid;
@@ -151,6 +118,5 @@ const homepageProjects = (await getCollection('work'))
 			/*border-radius: 4.5rem;*/
 			object-fit: cover;
 		}
-
 	}
 </style>


### PR DESCRIPTION
## Summary

Adds the editorial **What I bring** section directly below the homepage hero and replaces the outdated Services block.

- Adds three numbered positioning statements using the approved final copy
- Removes the heading width constraint so the lead lines can use the available column width
- Preserves the existing hero, selected-work order, project content, and View all work route

## Validation

- `npm run build -- --root /private/tmp/astro-portfolio-homepage-positioning`
- `git diff --check`

This is intentionally scoped to the positioning layer; it does not include the broader homepage identity POC changes.